### PR TITLE
reduce decision variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------------------
+Commit 2021.12.09 (Version 0.14.3)
+-------------------------------------------------------------------------------
+Implements changes that reduce the number of decision variables in the model to improve model speed.
+
+The variable `ExcessGen` has been converted to an Expression instead of a decision variable since it can be calculated as DispatchUpperLimit - DispatchGen. Because ExcessGen was indexed by [g,t], this is expected to significantly reduce model solve time.
+
+In addition, the variable `CurtailGen` has been reindexed to reduce the number of generators to which it applies. Previously, CurtailGen was indexed to all variable generators, even if those generators did not allow curtailment. We have now indexed this variable to a new set of generators `CURTAILABLE_GENS` which are defined based on whether the parameter `variable_gen_curtailment_limit` > 0. This should also significantly reduce the number of decision variables.
+
+-------------------------------------------------------------------------------
 Commit 2021.12.08 (Version 0.14.2)
 -------------------------------------------------------------------------------
 Removes the reduced cost summaries from the summary report. After further discussion and testing of this output, it was determined that there are too many decision variables that will affect choice outcomes to accurately interpret reduced costs from the model. 
@@ -14,7 +23,6 @@ Commit 2021.12.03 (Version 0.14.1)
 -------------------------------------------------------------------------------
 
 Bug fixes for summary reports, input file generation
-
 
 -------------------------------------------------------------------------------
 Commit 2021.12.02 (Version 0.14.0)

--- a/switch_model/generators/core/build.py
+++ b/switch_model/generators/core/build.py
@@ -471,6 +471,11 @@ def define_components(mod):
     #define the input parameter for the annual number of hours of curtialment/excess gen allowed
     mod.variable_gen_curtailment_limit = Param(mod.VARIABLE_GENS, within=NonNegativeReals, default=0)
 
+    # define a new set of curtailable gens that have a curtailment limit
+    mod.CURTAILABLE_GENS = Set(
+        initialize=mod.VARIABLE_GENS, 
+        filter=lambda m, g: m.variable_gen_curtailment_limit[g] > 0)
+
     # Derived annual costs
     mod.GenCapacityCost = Expression(
         mod.GENERATION_PROJECTS, mod.PERIODS,

--- a/switch_model/reporting/manually_run_reports.py
+++ b/switch_model/reporting/manually_run_reports.py
@@ -11,7 +11,7 @@ import shutil
 import pandas as pd
 
 # modify the file path to the name of the scenario for which you want to re-run the reporting
-run_folder = '../../MODEL_RUNS/historical_validation'
+run_folder = '../../MODEL_RUNS/test_grid_impact'
 #run_folder = '../../../../Box/Supply/24x7 Time-Coincident Work/MODEL_RUNS/test'
 
 scenarios = os.listdir(f'{run_folder}/outputs')

--- a/switch_model/version.py
+++ b/switch_model/version.py
@@ -9,4 +9,4 @@ installed.
 
 NOTE: MATCH was originally forked from Switch version 2.0.5
 """
-__version__='0.14.2'
+__version__='0.14.3'


### PR DESCRIPTION
-------------------------------------------------------------------------------
Commit 2021.12.09 (Version 0.14.3)
-------------------------------------------------------------------------------
Implements changes that reduce the number of decision variables in the model to improve model speed.

The variable `ExcessGen` has been converted to an Expression instead of a decision variable since it can be calculated as DispatchUpperLimit - DispatchGen. Because ExcessGen was indexed by [g,t], this is expected to significantly reduce model solve time.

In addition, the variable `CurtailGen` has been reindexed to reduce the number of generators to which it applies. Previously, CurtailGen was indexed to all variable generators, even if those generators did not allow curtailment. We have now indexed this variable to a new set of generators `CURTAILABLE_GENS` which are defined based on whether the parameter `variable_gen_curtailment_limit` > 0. This should also significantly reduce the number of decision variables.