### PR TITLE
fix hybrid dispatch bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------------------
+Commit 2022.07.14 (Version 0.22.2)
+-------------------------------------------------------------------------------
+Updates the hybrid generator dispatch constraint such that the net dispatch must be less than or equal to
+the nameplate capacity (DispatchGen + DischargeStorage - ChargeStorage <= capacity).
+
+Previously, the constraint was DispatchGen + DischargeStorage <= capacity, so if a generator
+ever had a variable capacity factor > 1, it would curtail the generation.
+
+-------------------------------------------------------------------------------
 Commit 2022.07.11 (Version 0.22.1)
 -------------------------------------------------------------------------------
 Updates the decision variable `CurtailGen` so that economic curtailment is only allowed when LMP prices are negative.

--- a/match_model/notebooks/manually_run_summary_reports.ipynb
+++ b/match_model/notebooks/manually_run_summary_reports.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_run_folder = \"../../../../../Public/MODEL_RUNS/247_Ascend_run_8\"\n",
+    "model_run_folder = \"../../../../../Public/MODEL_RUNS/test\"\n",
     "# model_run_folder = '../../MODEL_RUNS/test'"
    ]
   },

--- a/match_model/notebooks/run_scenarios.ipynb
+++ b/match_model/notebooks/run_scenarios.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/match_model/optional/storage.py
+++ b/match_model/optional/storage.py
@@ -9,7 +9,8 @@ storage, when to charge, energy accounting, etc.
 """
 
 from pyomo.environ import *
-import os, collections
+import os
+import collections
 
 dependencies = (
     "match_model.timescales",
@@ -334,7 +335,7 @@ def define_components(mod):
 
     # HYBRID STORAGE CHARGING
     #########################
-    # TODO: This will need to be modified if a dispatchable generator is a hybrid
+    # NOTE: This will need to be modified if a dispatchable generator is a hybrid
     mod.Charge_Hybrid_Storage_Upper_Limit = Constraint(
         mod.HYBRID_STORAGE_GEN_TPS,
         rule=lambda m, g, t: m.ChargeStorage[g, t]
@@ -345,10 +346,11 @@ def define_components(mod):
     # the total combined dispatch from the storage portion and the generator portion should not be allowed to exceed that
     # nameplate capacity. For example, a 100MW solar + 50MW storage hybrid project should only be allowed to dispatch
     # a combined total of 100MW in any timepoint.
-    # TODO: This will need to be updated if dispatchable generators can be hybrids
+    # NOTE: This will need to be updated if dispatchable generators can be hybrids
     mod.Hybrid_Discharge_Limit = Constraint(
         mod.HYBRID_STORAGE_GEN_TPS,
         rule=lambda m, g, t: m.DischargeStorage[g, t]
+        - m.ChargeStorage[g, t]
         + m.DispatchGen[m.storage_hybrid_generation_project[g], t]
         + m.ExcessGen[m.storage_hybrid_generation_project[g], t]
         <= m.GenCapacityInTP[m.storage_hybrid_generation_project[g], t],

--- a/match_model/version.py
+++ b/match_model/version.py
@@ -9,4 +9,4 @@ installed.
 
 NOTE: MATCH was originally forked from Switch version 2.0.5
 """
-__version__ = "0.22.1"
+__version__ = "0.22.2"


### PR DESCRIPTION
-------------------------------------------------------------------------------
Commit 2022.07.14 (Version 0.22.2)
-------------------------------------------------------------------------------
Updates the hybrid generator dispatch constraint such that the net dispatch must be less than or equal to
the nameplate capacity (DispatchGen + DischargeStorage - ChargeStorage <= capacity).

Previously, the constraint was DispatchGen + DischargeStorage <= capacity, so if a generator
ever had a variable capacity factor > 1, it would curtail the generation.